### PR TITLE
Reset tokens if there is an error with initial login

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -78,3 +78,7 @@ module.exports.refreshAuth = async ({ db }, { accessToken, instanceUrl }) => {
     [accessToken, instanceUrl, USER_ID]
   );
 };
+
+module.exports.dropAuth = async ({ db }) => {
+  await db.query(`DELETE FROM auth`);
+};

--- a/server/index.js
+++ b/server/index.js
@@ -205,7 +205,9 @@ module.exports = ({
 
   const start = async () => {
     await migrate(pgConfig);
-    await sf.login();
+    // If there is a problem with logging in, then logout which will clear auth and allow
+    // the user to start over
+    await sf.login().catch(() => sf.logout());
     await new Promise((resolve) => app.listen(port, resolve));
     return { port };
   };

--- a/server/salesforce.js
+++ b/server/salesforce.js
@@ -23,10 +23,11 @@ const findWebringUrlIndex = (webring, url) => {
 
 // Custom errors that should be responded to differently on the client
 class AuthError extends Error {
-  constructor() {
+  constructor(message) {
     super(
       'The component could not make a connection to Salesforce. Please <a href="{{host}}/sf/auth?redirect_host={{host}}" target="_blank">authenticate</a> to continue setup.'
     );
+    this.internalMessage = message;
     this.jsfErrorCode = "SF_AUTH";
     this.statusCode = 401;
   }
@@ -291,6 +292,11 @@ module.exports.init = ({ loginUrl, authUrl }, db) => {
     }
   };
 
+  const logout = async () => {
+    await db.dropAuth();
+    sf = null;
+  };
+
   const wrapApiMethod = (rawMethod) => async (...args) => {
     // try to login first
     if (sf === null) {
@@ -344,6 +350,7 @@ module.exports.init = ({ loginUrl, authUrl }, db) => {
     }, {}),
     login,
     connect,
+    logout,
     get connection() {
       return sf;
     },


### PR DESCRIPTION
I ran into this issue when switching my localhost from `test.salesforce.com` to `login.salesforce.com`. This shouldn't happen in production, but we should have a failsafe so problems with auth/refresh result in a new unauthed state instead of a failed server start.