### PR TITLE
Remove padding from containers

### DIFF
--- a/client/modules/wck/hitCounter/hitCounter.css
+++ b/client/modules/wck/hitCounter/hitCounter.css
@@ -5,7 +5,6 @@
   box-sizing: border-box;
   width: 100%;
   display: flex;
-  padding: 10px;
 }
 
 /* Hit Counter

--- a/client/modules/wck/webring/webring.css
+++ b/client/modules/wck/webring/webring.css
@@ -4,7 +4,6 @@
 .container {
   box-sizing: border-box;
   width: 100%;
-  padding: 10px;
 }
 
 /* Webring navigation
@@ -12,7 +11,7 @@
 
 .webring {
   box-sizing: border-box;
-  width: calc(100% - 20px);
+  width: calc(100% - 0.3em);
   background-image: linear-gradient(45deg, #79589f, #009edb);
   font-size: 100%;
   font-family: "Courier New", Courier, serif;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8605,8 +8605,7 @@
     "dotenv": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
-      "dev": true
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "duplexer": {
       "version": "0.1.2",


### PR DESCRIPTION
For: https://github.com/fostive/wicked-coolkit-user/issues/30

This PR:
- removes padding on `.container` for hit counter and webring
- adjusts margin for webring (accounting for box shadow) so the box shadow aligns with the right edge