### PR TITLE
feat: add target api pro to webring for prev/next links

### DIFF
--- a/client/modules/wck/webring/webring.html
+++ b/client/modules/wck/webring/webring.html
@@ -12,7 +12,12 @@
         </div>
       </div>
       <nav if:true={success}>
-        <a href={prevHref} class="previous" onclick={onLinkClick}>
+        <a
+          href={prevHref}
+          class="previous"
+          onclick={onLinkClick}
+          target={target}
+        >
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="12"
@@ -30,7 +35,7 @@
           </svg>
           Previous
         </a>
-        <a href={nextHref} class="next" onclick={onLinkClick}>
+        <a href={nextHref} class="next" onclick={onLinkClick} target={target}>
           Next
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/client/modules/wck/webring/webring.js
+++ b/client/modules/wck/webring/webring.js
@@ -9,6 +9,7 @@ export default class Webring extends LightningElement {
   nextHref = null;
 
   @api host = null;
+  @api target = null;
 
   get success() {
     return !this.loading && !this.error;


### PR DESCRIPTION
I was thinking this could be an undocumented feature so that user's (like me) could use `<wck-webring target="_blank">` and the webring would open in a new tab. This allows for the JS to update the prev/next links instead of them resetting on each load. 

The main reason I want this is I'm using the webring as a list of things I've built, but I can't easily add the webring to all those sites.