### PR TITLE
Add loading overlay when clicking a sticker that opens in the same window

### DIFF
--- a/client/modules/wck/tradingCard/tradingCard.css
+++ b/client/modules/wck/tradingCard/tradingCard.css
@@ -385,3 +385,25 @@ img {
 .sticker:hover {
   transform: scale(1.1);
 }
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  padding: 40px;
+  display: flex;
+  z-index: 10;
+}
+
+.overlay-content {
+  background-color: #fff;
+}
+
+.overlay-close {
+  position: absolute;
+  top: 40px;
+  right: 40px;
+}

--- a/client/modules/wck/tradingCard/tradingCard.css
+++ b/client/modules/wck/tradingCard/tradingCard.css
@@ -392,18 +392,80 @@ img {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  /*background: rgba(30,30,96,.5);*/
+  background-image: linear-gradient(
+    230deg,
+    rgba(121, 88, 159, 0.95),
+    rgba(0, 158, 219, 0.95)
+  );
   padding: 40px;
   display: flex;
   z-index: 10;
+  justify-content: center;
+  align-items: center;
 }
 
 .overlay-content {
-  background-color: #fff;
+  width: 100%;
+  max-width: 400px;
+  padding: 3em 1em;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  background-color: #f6f0e2;
+  border: 2px solid #1e1e60;
+  box-shadow: 0.4em 0.4em 0 #1e1e60;
+  font-family: "Courier New", serif;
+  font-size: 120%;
+  font-weight: bold;
+  color: #1e1e60;
+}
+
+.overlay-content > .loading {
+  width: 40px;
+  height: 50px;
+  display: block;
+  background-repeat: no-repeat;
+  background-image: linear-gradient(60deg, #f6f0e2 60%, #1e1e60 60.5%),
+    linear-gradient(60deg, #1e1e60 40%, #f6f0e2 40.5%);
+  background-size: 50% 50%;
+  background-position: 15% 100%, 95% 0;
+  animation: loading infinite linear 3000ms;
+}
+
+@keyframes loading {
+  from {
+    transform: rotate(0);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.overlay-content > p {
+  margin-top: 20px;
 }
 
 .overlay-close {
   position: absolute;
   top: 40px;
   right: 40px;
+  font-family: "Courier New", serif;
+  display: inline-block;
+  margin-bottom: 12px;
+  padding: 8px 15px;
+  border: 2px solid #009edb;
+  text-decoration: none;
+  font-weight: bold;
+  color: #009edb;
+  box-shadow: 4px 4px 0 #009edb;
+  transition: all 300ms ease-in-out;
+  cursor: pointer;
+}
+
+.overlay-close:hover {
+  background-color: white;
+  border-color: #1e1e60;
+  color: #1e1e60;
+  box-shadow: 6px 6px 0 #1e1e60;
 }

--- a/client/modules/wck/tradingCard/tradingCard.html
+++ b/client/modules/wck/tradingCard/tradingCard.html
@@ -165,10 +165,20 @@
     </div>
     <div class="back">
       <template for:each={stickers} for:item="sticker">
-        <a key={sticker.id} href={sticker.href} class="sticker">
+        <a
+          key={sticker.id}
+          href={sticker.href}
+          class="sticker"
+          onclick={onStickerClick}
+          data-sticker-name={sticker.name}
+        >
           <img src={sticker.imgSrc} alt={sticker.imgAlt} />
         </a>
       </template>
     </div>
+  </div>
+  <div class="overlay" if:true={loadingSticker}>
+    <button class="overlay-close" onclick={closeOverlay}>Close this</button>
+    <div class="overlay-content">Loading another {loadingSticker} person</div>
   </div>
 </template>

--- a/client/modules/wck/tradingCard/tradingCard.html
+++ b/client/modules/wck/tradingCard/tradingCard.html
@@ -170,15 +170,13 @@
           href={sticker.href}
           class="sticker"
           onclick={onStickerClick}
-          data-sticker-name={sticker.name}
         >
           <img src={sticker.imgSrc} alt={sticker.imgAlt} />
         </a>
       </template>
     </div>
   </div>
-  <!-- <div class="overlay" if:true={loadingSticker}> -->
-  <div class="overlay">
+  <div class="overlay" if:true={loadingSticker}>
     <button class="overlay-close" onclick={closeOverlay}>Close ×</button>
     <div class="overlay-content">
       <span class="loading"></span>

--- a/client/modules/wck/tradingCard/tradingCard.html
+++ b/client/modules/wck/tradingCard/tradingCard.html
@@ -177,8 +177,12 @@
       </template>
     </div>
   </div>
-  <div class="overlay" if:true={loadingSticker}>
-    <button class="overlay-close" onclick={closeOverlay}>Close this</button>
-    <div class="overlay-content">Loading another {loadingSticker} person</div>
+  <!-- <div class="overlay" if:true={loadingSticker}> -->
+  <div class="overlay">
+    <button class="overlay-close" onclick={closeOverlay}>Close ×</button>
+    <div class="overlay-content">
+      <span class="loading"></span>
+      <p>Loading another trading card</p>
+    </div>
   </div>
 </template>

--- a/client/modules/wck/tradingCard/tradingCard.js
+++ b/client/modules/wck/tradingCard/tradingCard.js
@@ -8,7 +8,7 @@ export default class TradingCard extends LightningElement {
   website = null;
   strengths = null;
   loading = true;
-  loadingSticker = null;
+  loadingSticker = false;
 
   @api host = null;
 
@@ -19,7 +19,6 @@ export default class TradingCard extends LightningElement {
       href: `${util.api(this.host)}/sticker/?name=${encodeURIComponent(
         sticker.path
       )}`,
-      name: sticker.path,
       imgSrc: util.sticker(sticker.path),
       imgAlt: sticker.alt,
     }));
@@ -31,14 +30,11 @@ export default class TradingCard extends LightningElement {
       return;
     }
 
-    // Uncomment this to test the loading indicator
-    // e.preventDefault();
-
-    this.loadingSticker = e.currentTarget.getAttribute("data-sticker-name");
+    this.loadingSticker = true;
   }
 
   closeOverlay() {
-    this.loadingSticker = null;
+    this.loadingSticker = false;
   }
 
   get email() {

--- a/client/modules/wck/tradingCard/tradingCard.js
+++ b/client/modules/wck/tradingCard/tradingCard.js
@@ -8,6 +8,7 @@ export default class TradingCard extends LightningElement {
   website = null;
   strengths = null;
   loading = true;
+  loadingSticker = null;
 
   @api host = null;
 
@@ -18,9 +19,26 @@ export default class TradingCard extends LightningElement {
       href: `${util.api(this.host)}/sticker/?name=${encodeURIComponent(
         sticker.path
       )}`,
+      name: sticker.path,
       imgSrc: util.sticker(sticker.path),
       imgAlt: sticker.alt,
     }));
+  }
+
+  onStickerClick(e) {
+    // Only for regular clicks
+    if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) {
+      return;
+    }
+
+    // Uncomment this to test the loading indicator
+    // e.preventDefault();
+
+    this.loadingSticker = e.currentTarget.getAttribute("data-sticker-name");
+  }
+
+  closeOverlay() {
+    this.loadingSticker = null;
   }
 
   get email() {


### PR DESCRIPTION
@lynnandtonic I went with the overlay because I thought it would be easier to style across different sites, but let me know if you'd rather make it a tooltip. The same JS should be able to be used, and just the styles/markup would need to change.

Fixes https://github.com/fostive/wicked-coolkit-user/issues/37